### PR TITLE
Fix: Invalid-length response errors are now handled

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -81,11 +81,16 @@ class Client {
 				this.socket.once('message', data => {
 					clearTimeout(timer);
 
-					const message = parse(data);
-
-					this.socket.close();
-
-					return resolve(message);
+					try {
+						const message = parse(data);
+						return resolve(message);
+					}
+					catch (error) {
+						return reject(error);
+					}
+					finally {
+						this.socket.close();
+					}					
 				});
 			});
 		});

--- a/src/client.js
+++ b/src/client.js
@@ -84,11 +84,9 @@ class Client {
 					try {
 						const message = parse(data);
 						return resolve(message);
-					}
-					catch (error) {
+					} catch (error) {
 						return reject(error);
-					}
-					finally {
+					} finally {
 						this.socket.close();
 					}					
 				});


### PR DESCRIPTION
When a NTP request returns a response that is not of the proper length, an error was thrown which was not handled. This addresses that.