### PR TITLE
use transmitTimestamp instead of originateTimestamp for client requests send time

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -7,7 +7,7 @@ const NTP_DELTA = 2208988800;
 function createPacket() {
 	const packet = new NTPPacket(MODES.CLIENT);
 
-	packet.originateTimestamp = Math.floor(Date.now() / 1000);
+	packet.txTimestamp = Math.floor(Date.now() / 1000); // should be transmitTimestamp according to index.d.ts
 
 	return packet.bufferize(packet);
 }


### PR DESCRIPTION
This solves #32 and #30
A wireshark comparison between the behavior of this lib and the `ntpdate` package revealed why all servers were returning originateTimestamp===NULL

**Note:** if #33 gets merged before this, we have to change txTimestamp to transmitTimestamp