### PR TITLE
fix client.js>createPacket(), transmitTimestamp instead of txTimestamp

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -7,7 +7,7 @@ const NTP_DELTA = 2208988800;
 function createPacket() {
 	const packet = new NTPPacket(MODES.CLIENT);
 
-	packet.txTimestamp = Math.floor(Date.now() / 1000); // should be transmitTimestamp according to index.d.ts
+	packet.transmitTimestamp = Math.floor(Date.now() / 1000);
 
 	return packet.bufferize(packet);
 }


### PR DESCRIPTION
txTimestamp has been changed to transmitTimestamp in 58f2cd0