### PR TITLE
fix(client.js): clean up leaked socket in constructor

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -46,7 +46,6 @@ class Client {
 	) {
 		this.server = server;
 		this.port = port;
-		this.socket = udp.createSocket('udp4');
 		this.options = options;
 
 		return this;


### PR DESCRIPTION
What
---
The constructor allocates a UDP socket but never uses it, this simply drops the socket allocation from the constructor 